### PR TITLE
Support for IAM service authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ A Go client library to interact with the [IBM Cloud® Secrets Manager APIs](http
 </details>
 
 ## Overview
-
 The IBM Cloud Secrets Manager Go SDK allows developers to programmatically interact with the following IBM Cloud services:
 
 | Service name                                                     | Package name     |

--- a/secretsmanagerv2/secrets_manager_v2.go
+++ b/secretsmanagerv2/secrets_manager_v2.go
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.94.1-71478489-20240820-161623
+ * IBM OpenAPI SDK Code Generator Version: 3.95.0-d0e386be-20240906-183310
  */
 
 // Package secretsmanagerv2 : Operations and models for the SecretsManagerV2 service
@@ -3189,6 +3189,9 @@ type Configuration struct {
 	// the [docs](https://cloud.ibm.com/docs/secrets-manager?topic=secrets-manager-configure-iam-engine).
 	ApiKey *string `json:"api_key,omitempty"`
 
+	// This parameter indicates whether the API key configuration is disabled.
+	Disabled *bool `json:"disabled,omitempty"`
+
 	// The Common Name (CN) represents the server name that is protected by the SSL certificate.
 	CommonName *string `json:"common_name,omitempty"`
 
@@ -4261,6 +4264,12 @@ type ConfigurationPatch struct {
 	// the [docs](https://cloud.ibm.com/docs/secrets-manager?topic=secrets-manager-configure-iam-engine).
 	ApiKey *string `json:"api_key,omitempty"`
 
+	// This parameter indicates whether the API key configuration is disabled.
+	//
+	// If it is set to `disabled`, the IAM credentials engine doesn't use the configured API key for credentials
+	// management.
+	Disabled *bool `json:"disabled,omitempty"`
+
 	// The maximum time-to-live (TTL) for certificates that are created by this CA.
 	//
 	// The value can be supplied as a string representation of a duration in hours, for example '8760h'. In the API
@@ -4534,6 +4543,11 @@ func UnmarshalConfigurationPatch(m map[string]json.RawMessage, result interface{
 		err = core.SDKErrorf(err, "", "api_key-error", common.GetComponentInfo())
 		return
 	}
+	err = core.UnmarshalPrimitive(m, "disabled", &obj.Disabled)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "disabled-error", common.GetComponentInfo())
+		return
+	}
 	err = core.UnmarshalPrimitive(m, "max_ttl", &obj.MaxTTL)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "max_ttl-error", common.GetComponentInfo())
@@ -4783,6 +4797,9 @@ func (configurationPatch *ConfigurationPatch) AsPatch() (_patch map[string]inter
 	_patch = map[string]interface{}{}
 	if !core.IsNil(configurationPatch.ApiKey) {
 		_patch["api_key"] = configurationPatch.ApiKey
+	}
+	if !core.IsNil(configurationPatch.Disabled) {
+		_patch["disabled"] = configurationPatch.Disabled
 	}
 	if !core.IsNil(configurationPatch.MaxTTL) {
 		_patch["max_ttl"] = configurationPatch.MaxTTL
@@ -5262,6 +5279,11 @@ type ConfigurationPrototype struct {
 
 	// The API key that is used to set the iam_credentials engine.
 	ApiKey *string `json:"api_key,omitempty"`
+
+	// This parameter indicates whether the API key configuration is disabled.
+	//
+	// If it is set to `true`, the IAM credentials engine doesn't use the configured API key for credentials management.
+	Disabled *bool `json:"disabled,omitempty"`
 }
 
 // Constants associated with the ConfigurationPrototype.ConfigType property.
@@ -7564,6 +7586,10 @@ type Secret struct {
 	// the `access_groups` parameter.
 	ServiceID *string `json:"service_id,omitempty"`
 
+	// The ID of the account in which the IAM credentials are created. Use this field only if the target account is not the
+	// same as the account of the Secrets Manager instance. Otherwise, the field can be omitted.
+	AccountID *string `json:"account_id,omitempty"`
+
 	// Indicates whether an `iam_credentials` secret was created with a static service ID.
 	//
 	// If it is set to `true`, the service ID for the secret was provided by the user at secret creation. If it is set to
@@ -8436,6 +8462,10 @@ type SecretMetadata struct {
 	// the `access_groups` parameter.
 	ServiceID *string `json:"service_id,omitempty"`
 
+	// The ID of the account in which the IAM credentials are created. Use this field only if the target account is not the
+	// same as the account of the Secrets Manager instance. Otherwise, the field can be omitted.
+	AccountID *string `json:"account_id,omitempty"`
+
 	// Indicates whether an `iam_credentials` secret was created with a static service ID.
 	//
 	// If it is set to `true`, the service ID for the secret was provided by the user at secret creation. If it is set to
@@ -8919,6 +8949,10 @@ type SecretPrototype struct {
 	// retain the service ID after your secret expires, is rotated, or deleted. If you provide a service ID, do not include
 	// the `access_groups` parameter.
 	ServiceID *string `json:"service_id,omitempty"`
+
+	// The ID of the account in which the IAM credentials are created. Use this field only if the target account is not the
+	// same as the account of the Secrets Manager instance. Otherwise, the field can be omitted.
+	AccountID *string `json:"account_id,omitempty"`
 
 	// (IAM credentials) This parameter indicates whether to reuse the service ID and API key for future read operations.
 	//
@@ -11750,6 +11784,9 @@ type IAMCredentialsConfiguration struct {
 	// on the Access Groups Service and the Operator platform role on the IAM Identity Service.  For more information, see
 	// the [docs](https://cloud.ibm.com/docs/secrets-manager?topic=secrets-manager-configure-iam-engine).
 	ApiKey *string `json:"api_key,omitempty"`
+
+	// This parameter indicates whether the API key configuration is disabled.
+	Disabled *bool `json:"disabled" validate:"required"`
 }
 
 // Constants associated with the IAMCredentialsConfiguration.ConfigType property.
@@ -11820,6 +11857,11 @@ func UnmarshalIAMCredentialsConfiguration(m map[string]json.RawMessage, result i
 	err = core.UnmarshalPrimitive(m, "api_key", &obj.ApiKey)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "api_key-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "disabled", &obj.Disabled)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "disabled-error", common.GetComponentInfo())
 		return
 	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
@@ -11926,19 +11968,13 @@ type IAMCredentialsConfigurationPatch struct {
 	// An IBM Cloud API key that can create and manage service IDs. The API key must be assigned the Editor platform role
 	// on the Access Groups Service and the Operator platform role on the IAM Identity Service.  For more information, see
 	// the [docs](https://cloud.ibm.com/docs/secrets-manager?topic=secrets-manager-configure-iam-engine).
-	ApiKey *string `json:"api_key" validate:"required"`
-}
+	ApiKey *string `json:"api_key,omitempty"`
 
-// NewIAMCredentialsConfigurationPatch : Instantiate IAMCredentialsConfigurationPatch (Generic Model Constructor)
-func (*SecretsManagerV2) NewIAMCredentialsConfigurationPatch(apiKey string) (_model *IAMCredentialsConfigurationPatch, err error) {
-	_model = &IAMCredentialsConfigurationPatch{
-		ApiKey: core.StringPtr(apiKey),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	if err != nil {
-		err = core.SDKErrorf(err, "", "model-missing-required", common.GetComponentInfo())
-	}
-	return
+	// This parameter indicates whether the API key configuration is disabled.
+	//
+	// If it is set to `disabled`, the IAM credentials engine doesn't use the configured API key for credentials
+	// management.
+	Disabled *bool `json:"disabled,omitempty"`
 }
 
 func (*IAMCredentialsConfigurationPatch) isaConfigurationPatch() bool {
@@ -11953,6 +11989,11 @@ func UnmarshalIAMCredentialsConfigurationPatch(m map[string]json.RawMessage, res
 		err = core.SDKErrorf(err, "", "api_key-error", common.GetComponentInfo())
 		return
 	}
+	err = core.UnmarshalPrimitive(m, "disabled", &obj.Disabled)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "disabled-error", common.GetComponentInfo())
+		return
+	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
 	return
 }
@@ -11962,6 +12003,9 @@ func (iAMCredentialsConfigurationPatch *IAMCredentialsConfigurationPatch) AsPatc
 	_patch = map[string]interface{}{}
 	if !core.IsNil(iAMCredentialsConfigurationPatch.ApiKey) {
 		_patch["api_key"] = iAMCredentialsConfigurationPatch.ApiKey
+	}
+	if !core.IsNil(iAMCredentialsConfigurationPatch.Disabled) {
+		_patch["disabled"] = iAMCredentialsConfigurationPatch.Disabled
 	}
 
 	return
@@ -11982,6 +12026,11 @@ type IAMCredentialsConfigurationPrototype struct {
 
 	// The API key that is used to set the iam_credentials engine.
 	ApiKey *string `json:"api_key" validate:"required"`
+
+	// This parameter indicates whether the API key configuration is disabled.
+	//
+	// If it is set to `true`, the IAM credentials engine doesn't use the configured API key for credentials management.
+	Disabled *bool `json:"disabled,omitempty"`
 }
 
 // Constants associated with the IAMCredentialsConfigurationPrototype.ConfigType property.
@@ -12032,6 +12081,11 @@ func UnmarshalIAMCredentialsConfigurationPrototype(m map[string]json.RawMessage,
 	err = core.UnmarshalPrimitive(m, "api_key", &obj.ApiKey)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "api_key-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "disabled", &obj.Disabled)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "disabled-error", common.GetComponentInfo())
 		return
 	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
@@ -12128,6 +12182,10 @@ type IAMCredentialsSecret struct {
 	// retain the service ID after your secret expires, is rotated, or deleted. If you provide a service ID, do not include
 	// the `access_groups` parameter.
 	ServiceID *string `json:"service_id,omitempty"`
+
+	// The ID of the account in which the IAM credentials are created. Use this field only if the target account is not the
+	// same as the account of the Secrets Manager instance. Otherwise, the field can be omitted.
+	AccountID *string `json:"account_id,omitempty"`
 
 	// Indicates whether an `iam_credentials` secret was created with a static service ID.
 	//
@@ -12299,6 +12357,11 @@ func UnmarshalIAMCredentialsSecret(m map[string]json.RawMessage, result interfac
 		err = core.SDKErrorf(err, "", "service_id-error", common.GetComponentInfo())
 		return
 	}
+	err = core.UnmarshalPrimitive(m, "account_id", &obj.AccountID)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "account_id-error", common.GetComponentInfo())
+		return
+	}
 	err = core.UnmarshalPrimitive(m, "service_id_is_static", &obj.ServiceIdIsStatic)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "service_id_is_static-error", common.GetComponentInfo())
@@ -12423,6 +12486,10 @@ type IAMCredentialsSecretMetadata struct {
 	// retain the service ID after your secret expires, is rotated, or deleted. If you provide a service ID, do not include
 	// the `access_groups` parameter.
 	ServiceID *string `json:"service_id,omitempty"`
+
+	// The ID of the account in which the IAM credentials are created. Use this field only if the target account is not the
+	// same as the account of the Secrets Manager instance. Otherwise, the field can be omitted.
+	AccountID *string `json:"account_id,omitempty"`
 
 	// Indicates whether an `iam_credentials` secret was created with a static service ID.
 	//
@@ -12585,6 +12652,11 @@ func UnmarshalIAMCredentialsSecretMetadata(m map[string]json.RawMessage, result 
 	err = core.UnmarshalPrimitive(m, "service_id", &obj.ServiceID)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "service_id-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "account_id", &obj.AccountID)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "account_id-error", common.GetComponentInfo())
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "service_id_is_static", &obj.ServiceIdIsStatic)
@@ -12772,6 +12844,10 @@ type IAMCredentialsSecretPrototype struct {
 	// the `access_groups` parameter.
 	ServiceID *string `json:"service_id,omitempty"`
 
+	// The ID of the account in which the IAM credentials are created. Use this field only if the target account is not the
+	// same as the account of the Secrets Manager instance. Otherwise, the field can be omitted.
+	AccountID *string `json:"account_id,omitempty"`
+
 	// (IAM credentials) This parameter indicates whether to reuse the service ID and API key for future read operations.
 	//
 	// If it is set to `true`, the service reuses the current credentials. If it is set to `false`, a new service ID and
@@ -12863,6 +12939,11 @@ func UnmarshalIAMCredentialsSecretPrototype(m map[string]json.RawMessage, result
 	err = core.UnmarshalPrimitive(m, "service_id", &obj.ServiceID)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "service_id-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "account_id", &obj.AccountID)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "account_id-error", common.GetComponentInfo())
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "reuse_api_key", &obj.ReuseApiKey)

--- a/secretsmanagerv2/secrets_manager_v2.go
+++ b/secretsmanagerv2/secrets_manager_v2.go
@@ -3184,13 +3184,13 @@ type Configuration struct {
 	// [docs](https://cloud.ibm.com/docs/account?topic=account-classic_keys).
 	ClassicInfrastructurePassword *string `json:"classic_infrastructure_password,omitempty"`
 
+	// This parameter indicates whether the API key configuration is disabled.
+	Disabled *bool `json:"disabled,omitempty"`
+
 	// An IBM Cloud API key that can create and manage service IDs. The API key must be assigned the Editor platform role
 	// on the Access Groups Service and the Operator platform role on the IAM Identity Service.  For more information, see
 	// the [docs](https://cloud.ibm.com/docs/secrets-manager?topic=secrets-manager-configure-iam-engine).
 	ApiKey *string `json:"api_key,omitempty"`
-
-	// This parameter indicates whether the API key configuration is disabled.
-	Disabled *bool `json:"disabled,omitempty"`
 
 	// The Common Name (CN) represents the server name that is protected by the SSL certificate.
 	CommonName *string `json:"common_name,omitempty"`
@@ -3976,6 +3976,9 @@ type ConfigurationMetadata struct {
 
 	// The date when a resource was modified. The date format follows `RFC 3339`.
 	UpdatedAt *strfmt.DateTime `json:"updated_at,omitempty"`
+
+	// This parameter indicates whether the API key configuration is disabled.
+	Disabled *bool `json:"disabled,omitempty"`
 
 	// The configuration of the Let's Encrypt CA environment.
 	LetsEncryptEnvironment *string `json:"lets_encrypt_environment,omitempty"`
@@ -11780,13 +11783,13 @@ type IAMCredentialsConfiguration struct {
 	// The date when a resource was modified. The date format follows `RFC 3339`.
 	UpdatedAt *strfmt.DateTime `json:"updated_at" validate:"required"`
 
+	// This parameter indicates whether the API key configuration is disabled.
+	Disabled *bool `json:"disabled,omitempty"`
+
 	// An IBM Cloud API key that can create and manage service IDs. The API key must be assigned the Editor platform role
 	// on the Access Groups Service and the Operator platform role on the IAM Identity Service.  For more information, see
 	// the [docs](https://cloud.ibm.com/docs/secrets-manager?topic=secrets-manager-configure-iam-engine).
 	ApiKey *string `json:"api_key,omitempty"`
-
-	// This parameter indicates whether the API key configuration is disabled.
-	Disabled *bool `json:"disabled" validate:"required"`
 }
 
 // Constants associated with the IAMCredentialsConfiguration.ConfigType property.
@@ -11854,14 +11857,14 @@ func UnmarshalIAMCredentialsConfiguration(m map[string]json.RawMessage, result i
 		err = core.SDKErrorf(err, "", "updated_at-error", common.GetComponentInfo())
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "api_key", &obj.ApiKey)
-	if err != nil {
-		err = core.SDKErrorf(err, "", "api_key-error", common.GetComponentInfo())
-		return
-	}
 	err = core.UnmarshalPrimitive(m, "disabled", &obj.Disabled)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "disabled-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "api_key", &obj.ApiKey)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "api_key-error", common.GetComponentInfo())
 		return
 	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
@@ -11891,6 +11894,9 @@ type IAMCredentialsConfigurationMetadata struct {
 
 	// The date when a resource was modified. The date format follows `RFC 3339`.
 	UpdatedAt *strfmt.DateTime `json:"updated_at" validate:"required"`
+
+	// This parameter indicates whether the API key configuration is disabled.
+	Disabled *bool `json:"disabled,omitempty"`
 }
 
 // Constants associated with the IAMCredentialsConfigurationMetadata.ConfigType property.
@@ -11956,6 +11962,11 @@ func UnmarshalIAMCredentialsConfigurationMetadata(m map[string]json.RawMessage, 
 	err = core.UnmarshalPrimitive(m, "updated_at", &obj.UpdatedAt)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "updated_at-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "disabled", &obj.Disabled)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "disabled-error", common.GetComponentInfo())
 		return
 	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))

--- a/secretsmanagerv2/secrets_manager_v2_test.go
+++ b/secretsmanagerv2/secrets_manager_v2_test.go
@@ -9466,12 +9466,6 @@ var _ = Describe(`SecretsManagerV2`, func() {
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})
-			It(`Invoke NewIAMCredentialsConfigurationPatch successfully`, func() {
-				apiKey := "testString"
-				_model, err := secretsManagerService.NewIAMCredentialsConfigurationPatch(apiKey)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
 			It(`Invoke NewIAMCredentialsConfigurationPrototype successfully`, func() {
 				name := "my-example-engine-config"
 				configType := "iam_credentials_configuration"
@@ -9740,6 +9734,7 @@ var _ = Describe(`SecretsManagerV2`, func() {
 			// Construct an instance of the model.
 			model := new(secretsmanagerv2.ConfigurationPatch)
 			model.ApiKey = core.StringPtr("testString")
+			model.Disabled = core.BoolPtr(true)
 			model.MaxTTL = core.StringPtr("8760h")
 			model.CrlExpiry = core.StringPtr("72h")
 			model.CrlDisable = core.BoolPtr(true)
@@ -9871,6 +9866,7 @@ var _ = Describe(`SecretsManagerV2`, func() {
 			model.BasicConstraintsValidForNonCa = core.BoolPtr(true)
 			model.NotBeforeDuration = core.StringPtr("30s")
 			model.ApiKey = core.StringPtr("testString")
+			model.Disabled = core.BoolPtr(false)
 
 			b, err := json.Marshal(model)
 			Expect(err).To(BeNil())
@@ -10102,6 +10098,7 @@ var _ = Describe(`SecretsManagerV2`, func() {
 			model.TTL = core.StringPtr("1d")
 			model.AccessGroups = []string{"AccessGroupId-45884031-54be-4dd7-86ff-112511e92699"}
 			model.ServiceID = core.StringPtr("ServiceId-bb4ccc31-bd31-493a-bb58-52ec399800be")
+			model.AccountID = core.StringPtr("708d4dc20986423e79bb8512f81b7f92")
 			model.ReuseApiKey = core.BoolPtr(true)
 			model.Rotation = nil
 			model.Certificate = core.StringPtr("testString")
@@ -10368,6 +10365,7 @@ var _ = Describe(`SecretsManagerV2`, func() {
 			// Construct an instance of the model.
 			model := new(secretsmanagerv2.IAMCredentialsConfigurationPatch)
 			model.ApiKey = core.StringPtr("testString")
+			model.Disabled = core.BoolPtr(true)
 
 			b, err := json.Marshal(model)
 			Expect(err).To(BeNil())
@@ -10388,6 +10386,7 @@ var _ = Describe(`SecretsManagerV2`, func() {
 			model.Name = core.StringPtr("my-example-engine-config")
 			model.ConfigType = core.StringPtr("iam_credentials_configuration")
 			model.ApiKey = core.StringPtr("testString")
+			model.Disabled = core.BoolPtr(false)
 
 			b, err := json.Marshal(model)
 			Expect(err).To(BeNil())
@@ -10436,6 +10435,7 @@ var _ = Describe(`SecretsManagerV2`, func() {
 			model.TTL = core.StringPtr("1d")
 			model.AccessGroups = []string{"AccessGroupId-45884031-54be-4dd7-86ff-112511e92699"}
 			model.ServiceID = core.StringPtr("ServiceId-bb4ccc31-bd31-493a-bb58-52ec399800be")
+			model.AccountID = core.StringPtr("708d4dc20986423e79bb8512f81b7f92")
 			model.ReuseApiKey = core.BoolPtr(true)
 			model.Rotation = nil
 			model.CustomMetadata = map[string]interface{}{"anyKey": "anyValue"}

--- a/secretsmanagerv2/secrets_manager_v2_test.go
+++ b/secretsmanagerv2/secrets_manager_v2_test.go
@@ -7134,7 +7134,7 @@ var _ = Describe(`SecretsManagerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"total_count": 0, "limit": 25, "offset": 25, "first": {"href": "Href"}, "next": {"href": "Href"}, "previous": {"href": "Href"}, "last": {"href": "Href"}, "configurations": [{"config_type": "iam_credentials_configuration", "name": "my-secret-engine-config", "secret_type": "arbitrary", "created_by": "iam-ServiceId-e4a2f0a4-3c76-4bef-b1f2-fbeae11c0f21", "created_at": "2022-04-12T23:20:50.520Z", "updated_at": "2022-04-12T23:20:50.520Z"}]}`)
+					fmt.Fprintf(res, "%s", `{"total_count": 0, "limit": 25, "offset": 25, "first": {"href": "Href"}, "next": {"href": "Href"}, "previous": {"href": "Href"}, "last": {"href": "Href"}, "configurations": [{"config_type": "iam_credentials_configuration", "name": "my-secret-engine-config", "secret_type": "arbitrary", "created_by": "iam-ServiceId-e4a2f0a4-3c76-4bef-b1f2-fbeae11c0f21", "created_at": "2022-04-12T23:20:50.520Z", "updated_at": "2022-04-12T23:20:50.520Z", "disabled": true}]}`)
 				}))
 			})
 			It(`Invoke ListConfigurations successfully with retries`, func() {
@@ -7196,7 +7196,7 @@ var _ = Describe(`SecretsManagerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"total_count": 0, "limit": 25, "offset": 25, "first": {"href": "Href"}, "next": {"href": "Href"}, "previous": {"href": "Href"}, "last": {"href": "Href"}, "configurations": [{"config_type": "iam_credentials_configuration", "name": "my-secret-engine-config", "secret_type": "arbitrary", "created_by": "iam-ServiceId-e4a2f0a4-3c76-4bef-b1f2-fbeae11c0f21", "created_at": "2022-04-12T23:20:50.520Z", "updated_at": "2022-04-12T23:20:50.520Z"}]}`)
+					fmt.Fprintf(res, "%s", `{"total_count": 0, "limit": 25, "offset": 25, "first": {"href": "Href"}, "next": {"href": "Href"}, "previous": {"href": "Href"}, "last": {"href": "Href"}, "configurations": [{"config_type": "iam_credentials_configuration", "name": "my-secret-engine-config", "secret_type": "arbitrary", "created_by": "iam-ServiceId-e4a2f0a4-3c76-4bef-b1f2-fbeae11c0f21", "created_at": "2022-04-12T23:20:50.520Z", "updated_at": "2022-04-12T23:20:50.520Z", "disabled": true}]}`)
 				}))
 			})
 			It(`Invoke ListConfigurations successfully`, func() {
@@ -7350,9 +7350,9 @@ var _ = Describe(`SecretsManagerV2`, func() {
 					res.WriteHeader(200)
 					requestNumber++
 					if requestNumber == 1 {
-						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?offset=1"},"total_count":2,"configurations":[{"config_type":"iam_credentials_configuration","name":"my-secret-engine-config","secret_type":"arbitrary","created_by":"iam-ServiceId-e4a2f0a4-3c76-4bef-b1f2-fbeae11c0f21","created_at":"2022-04-12T23:20:50.520Z","updated_at":"2022-04-12T23:20:50.520Z"}],"limit":1}`)
+						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?offset=1"},"total_count":2,"configurations":[{"config_type":"iam_credentials_configuration","name":"my-secret-engine-config","secret_type":"arbitrary","created_by":"iam-ServiceId-e4a2f0a4-3c76-4bef-b1f2-fbeae11c0f21","created_at":"2022-04-12T23:20:50.520Z","updated_at":"2022-04-12T23:20:50.520Z","disabled":true}],"limit":1}`)
 					} else if requestNumber == 2 {
-						fmt.Fprintf(res, "%s", `{"total_count":2,"configurations":[{"config_type":"iam_credentials_configuration","name":"my-secret-engine-config","secret_type":"arbitrary","created_by":"iam-ServiceId-e4a2f0a4-3c76-4bef-b1f2-fbeae11c0f21","created_at":"2022-04-12T23:20:50.520Z","updated_at":"2022-04-12T23:20:50.520Z"}],"limit":1}`)
+						fmt.Fprintf(res, "%s", `{"total_count":2,"configurations":[{"config_type":"iam_credentials_configuration","name":"my-secret-engine-config","secret_type":"arbitrary","created_by":"iam-ServiceId-e4a2f0a4-3c76-4bef-b1f2-fbeae11c0f21","created_at":"2022-04-12T23:20:50.520Z","updated_at":"2022-04-12T23:20:50.520Z","disabled":true}],"limit":1}`)
 					} else {
 						res.WriteHeader(400)
 					}


### PR DESCRIPTION
Create IAM credentials based on service to service authorizations with IAM service, instead of API key configuration.